### PR TITLE
fix ReadFrom

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -261,6 +261,7 @@ func (f *BloomFilter) ReadFrom(stream io.Reader) (int64, error) {
 	f.m = uint(m)
 	f.k = uint(k)
 	f.b = b
+	f.locBuff = make([]uint, k)
 	f.hasher = fnv.New64()
 	return numBytes + int64(2*binary.Size(uint64(0))), nil
 }

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -133,6 +133,35 @@ func TestMarshalUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestWriteToReadFrom(t *testing.T) {
+	var b bytes.Buffer
+	f := New(1000, 4)
+	_, err := f.WriteTo(&b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := New(1000, 1)
+	_, err = g.ReadFrom(&b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.m != f.m {
+		t.Error("invalid m value")
+	}
+	if g.k != f.k {
+		t.Error("invalid k value")
+	}
+	if g.b == nil {
+		t.Fatal("bitset is nil")
+	}
+	if !g.b.Equal(f.b) {
+		t.Error("bitsets are not equal")
+	}
+
+	g.Test([]byte(""))
+}
+
 func TestReadWriteBinary(t *testing.T) {
 	f := New(1000, 4)
 	var buf bytes.Buffer


### PR DESCRIPTION
```locBuff``` field was not allocated on ```ReadFrom```. It was causing panic when ```Test``` is called.