### PR TITLE
Concurrent

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -53,6 +53,8 @@ bloom filter for a set of size _n_:
 
 Given the particular hashing scheme, it's best to be empirical about this. Note
 that estimating the FP rate will clear the Bloom filter.
+
+BloomFilter methods are not safe for concurrent usage except TestConcurrent method.
 */
 package bloom
 

--- a/bloom.go
+++ b/bloom.go
@@ -144,7 +144,7 @@ func (f *BloomFilter) Add(data []byte) *BloomFilter {
 	return f
 }
 
-// Tests for the presence of data in the Bloom filter
+// Test for the presence of data in the Bloom filter
 func (f *BloomFilter) Test(data []byte) bool {
 	f.locations(data)
 	for i := uint(0); i < f.k; i++ {

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -82,7 +82,7 @@ func TestConcurrent(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		for i := 0; i < try; i++ {
-			n1b := f.Test(n1)
+			n1b := f.TestConcurrent(n1)
 			if !n1b {
 				err1 = fmt.Errorf("%v should be in.", n1)
 				break
@@ -94,7 +94,7 @@ func TestConcurrent(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		for i := 0; i < try; i++ {
-			n2b := f.Test(n2)
+			n2b := f.TestConcurrent(n2)
 			if !n2b {
 				err2 = fmt.Errorf("%v should be in.", n2)
 				break

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 )
 
@@ -60,6 +62,54 @@ func TestBasicUint32(t *testing.T) {
 	}
 	if !n3b {
 		t.Errorf("%v should be in the second time we look.", n3)
+	}
+}
+
+func TestConcurrent(t *testing.T) {
+	gmp := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(gmp)
+
+	f := New(1000, 4)
+	n1 := []byte("Bess")
+	n2 := []byte("Jane")
+	f.Add(n1)
+	f.Add(n2)
+
+	var wg sync.WaitGroup
+	const try = 1000
+	var err1, err2 error
+
+	wg.Add(1)
+	go func() {
+		for i := 0; i < try; i++ {
+			n1b := f.Test(n1)
+			if !n1b {
+				err1 = fmt.Errorf("%v should be in.", n1)
+				break
+			}
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		for i := 0; i < try; i++ {
+			n2b := f.Test(n2)
+			if !n2b {
+				err2 = fmt.Errorf("%v should be in.", n2)
+				break
+			}
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if err2 != nil {
+		t.Fatal(err2)
 	}
 }
 


### PR DESCRIPTION
I use the package for filtering some data in web requests. Since ```BloomFilter``` structure uses shared ```locBuff``` and ```hasher``` fields it is not safe to call ```Test``` function from multiple goroutines (included a test case to demonstrate the problem). I have added another method (```TestConcurrent```) that does not use these shared fileds. Feel free to reject if you don't like the idea.