### PR TITLE
Test locations

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -90,10 +90,14 @@ func baseHashes(data []byte) [4]uint64 {
 }
 
 // location returns the ith hashed location using the four base hash values
-func (f *BloomFilter) location(h [4]uint64, i uint) (location uint) {
+func location(h [4]uint64, i uint) uint64 {
 	ii := uint64(i)
-	location = uint((h[ii%2] + ii*h[2+(((ii+(ii%2))%4)/2)]) % uint64(f.m))
-	return
+	return h[ii%2] + ii*h[2+(((ii+(ii%2))%4)/2)]
+}
+
+// location returns the ith hashed location using the four base hash values
+func (f *BloomFilter) location(h [4]uint64, i uint) uint {
+	return uint(location(h, i) % uint64(f.m))
 }
 
 // EstimateParameters estimates requirements for m and k.
@@ -328,12 +332,6 @@ func (f *BloomFilter) GobDecode(data []byte) error {
 // Equal tests for the equality of two Bloom filters
 func (f *BloomFilter) Equal(g *BloomFilter) bool {
 	return f.m == g.m && f.k == g.k && f.b.Equal(g.b)
-}
-
-// location returns the ith hashed location using the four base hash values
-func location(h [4]uint64, i uint) uint64 {
-	ii := uint64(i)
-	return h[ii%2] + ii*h[2+(((ii+(ii%2))%4)/2)]
 }
 
 // Locations returns a list of hash locations representing a data item.

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -515,3 +515,33 @@ func TestCopy(t *testing.T) {
 		t.Errorf("The value doesn't exist in copy after Add()")
 	}
 }
+
+func TestTestLocations(t *testing.T) {
+	f := NewWithEstimates(1000, 0.001)
+	n1 := []byte("Love")
+	n2 := []byte("is")
+	n3 := []byte("in")
+	n4 := []byte("bloom")
+	f.Add(n1)
+	n3a := f.TestLocations(Locations(n3, f.K()))
+	f.Add(n3)
+	n1b := f.TestLocations(Locations(n1, f.K()))
+	n2b := f.TestLocations(Locations(n2, f.K()))
+	n3b := f.TestLocations(Locations(n3, f.K()))
+	n4b := f.TestLocations(Locations(n4, f.K()))
+	if !n1b {
+		t.Errorf("%v should be in.", n1)
+	}
+	if n2b {
+		t.Errorf("%v should not be in.", n2)
+	}
+	if n3a {
+		t.Errorf("%v should not be in the first time we look.", n3)
+	}
+	if !n3b {
+		t.Errorf("%v should be in the second time we look.", n3)
+	}
+	if n4b {
+		t.Errorf("%v should be in.", n4)
+	}
+}


### PR DESCRIPTION
This PR adds the possibility to test specific locations in a BloomFilter. In some scenarios that data items are tested very frequently for different BloomFilters. We can drastically improve performance if we pre-compute the hash locations of the items and test them.

Here is a simple example of how that could be used.
```
// precompute k hash locations for an item
locs := Locations(n1, k)

// test the item in multiple filters and return if found
for _, b := range filters {
  if b.TestLocations(locs) {
    return true
  }
}
return false
```
